### PR TITLE
Task 643: Fixed route parameters

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,23 +83,24 @@ func main() {
 		}
 	})
 
-	server.PUT("/telemetry/:id", func(c *gin.Context) {
-		id := c.Param("id")    // Extract the ID from the URL path
+	server.PUT("/telemetry/", func(c *gin.Context) {
+		id := c.Query("id")    // Extract the ID from the URL path
 		var data TelemetryData // Create an empty TelemetryData struct
-
+		fmt.Println(id)
 		// Attempt to parse the incoming request's JSON into the "data" struct
 		if err := c.ShouldBindJSON(&data); err != nil {
 			c.JSON(400, gin.H{"error": err.Error()})
 			return
 		}
+
 		telemetryDB[id] = data // Store the parsed data in our mock database
 		c.JSON(200, data)      // Respond with a 200 status and the stored data
 		c.JSON(200, gin.H{"message": "Data saved successfully!"})
 	})
 
-	server.GET("/telemetry/:id", func(c *gin.Context) {
-		id := c.Param("id") // Extract Id from URL path
-
+	server.GET("/telemetry/", func(c *gin.Context) {
+		id := c.Query("id") // Extract Id from URL path
+		fmt.Println(telemetryDB)
 		if data, ok := telemetryDB[id]; ok {
 			c.HTML(http.StatusOK, "index.tmpl", gin.H{
 				"coordsX":      data.Coordinates.X,

--- a/test/test.http
+++ b/test/test.http
@@ -1,4 +1,4 @@
-PUT http://localhost:8080/telemetry/1 HTTP/1.1
+PUT http://localhost:8080/telemetry?id=1 HTTP/1.1
 content-type:application/json
 
 {
@@ -11,7 +11,7 @@ content-type:application/json
 
 ###
 
-GET http://localhost:8080/telemetry/1
+GET http://localhost:8080/telemetry/?id=1
 
 ###
 


### PR DESCRIPTION
This PR is me working on Issue 643, where both the PUT and GET /telemetry route used route parameters instead of query parameters. This pull request is to fix that.

This is the resource I used to work with [Query Parameters](https://gin-gonic.com/docs/examples/query-and-post-form/).