### PR TITLE
Task 724 and 795: Implement GET /uplink

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,18 +72,22 @@ func serveCSS(c *gin.Context) {
 }
 
 func status(c *gin.Context) {
-	uri := fmt.Sprintf("http://%s:8080/test", listIPs[5])
-	//I'll have to implement all the error handling
+	uri := fmt.Sprintf("http://%s:8080/status", listIPs[4])
+
+	//Error handling not implemented on purpose because
+	// "An error is returned if there were too many redirects or if there was an HTTP protocol error.
+	// A non-2xx response doesn't cause an error."
 	res, _ := http.Get(uri)
 	defer res.Body.Close()
+
+	// make a 2D array of an interface and string
 	var body map[string]interface{}
+	//json decoder writes to body by address
 	json.NewDecoder(res.Body).Decode(&body)
+
+	//returns the status code and the body in a raw format
 	c.JSON(res.StatusCode, body)
 
-}
-
-func test(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"response": "hey!"})
 }
 
 func readIPCFG() {
@@ -110,7 +114,6 @@ func main() {
 	server.PUT("/telemetry/", putTelemetry)
 	server.GET("/telemetry/", getTelemetry)
 	server.GET("/status", status)
-	server.GET("/test", test)
 	server.Run() // By default, it will start the server on http://localhost:8080
 
 }

--- a/main.go
+++ b/main.go
@@ -73,18 +73,15 @@ func serveCSS(c *gin.Context) {
 
 func status(c *gin.Context) {
 	uri := fmt.Sprintf("http://%s:8080/test", listIPs[5])
-	fmt.Println(uri)
 	//I'll have to implement all the error handling
 	req, _ := http.NewRequest(http.MethodGet, uri, nil)
 	res, _ := http.DefaultClient.Do(req)
 	resBody, _ := io.ReadAll(res.Body)
-	fmt.Println(res)
-	c.JSON(res.StatusCode, resBody)
+	c.JSON(res.StatusCode, gin.H{"JSON": resBody})
 }
 
 func test(c *gin.Context) {
-	c.IndentedJSON(http.StatusNotFound, gin.H{"response": "hey!"})
-
+	c.JSON(http.StatusOK, gin.H{"response": "hey!"})
 }
 
 func readIPCFG() {

--- a/main.go
+++ b/main.go
@@ -71,19 +71,17 @@ func serveCSS(c *gin.Context) {
 }
 
 func status(c *gin.Context) {
-	req, _ := http.NewRequest(http.MethodGet, "http://localhost:8080/status", nil)
+	uri := fmt.Sprintf("http://%s:8080/test", listIPs[5])
+	fmt.Println(uri)
+	req, _ := http.NewRequest(http.MethodGet, uri, nil)
 	res, _ := http.DefaultClient.Do(req)
-	c.JSON(res.StatusCode, gin.H{
-		"message": "check",
-	})
+	//insert code for JSON here
+	c.JSON(res.StatusCode)
 }
 
 func test(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"response": "hey!"})
 
-	fmt.Println(res)
-	c.JSON(200, gin.H{
-		"message": "pong",
-	})
 }
 
 func readIPCFG() {

--- a/main.go
+++ b/main.go
@@ -78,11 +78,12 @@ func status(c *gin.Context) {
 	req, _ := http.NewRequest(http.MethodGet, uri, nil)
 	res, _ := http.DefaultClient.Do(req)
 	resBody, _ := io.ReadAll(res.Body)
+	fmt.Println(res)
 	c.JSON(res.StatusCode, resBody)
 }
 
 func test(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"response": "hey!"})
+	c.IndentedJSON(http.StatusNotFound, gin.H{"response": "hey!"})
 
 }
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -73,10 +74,11 @@ func serveCSS(c *gin.Context) {
 func status(c *gin.Context) {
 	uri := fmt.Sprintf("http://%s:8080/test", listIPs[5])
 	fmt.Println(uri)
+	//I'll have to implement all the error handling
 	req, _ := http.NewRequest(http.MethodGet, uri, nil)
 	res, _ := http.DefaultClient.Do(req)
-	//insert code for JSON here
-	c.JSON(res.StatusCode)
+	resBody, _ := io.ReadAll(res.Body)
+	c.JSON(res.StatusCode, resBody)
 }
 
 func test(c *gin.Context) {

--- a/main.go
+++ b/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -74,10 +74,12 @@ func serveCSS(c *gin.Context) {
 func status(c *gin.Context) {
 	uri := fmt.Sprintf("http://%s:8080/test", listIPs[5])
 	//I'll have to implement all the error handling
-	req, _ := http.NewRequest(http.MethodGet, uri, nil)
-	res, _ := http.DefaultClient.Do(req)
-	resBody, _ := io.ReadAll(res.Body)
-	c.JSON(res.StatusCode, gin.H{"JSON": resBody})
+	res, _ := http.Get(uri)
+	defer res.Body.Close()
+	var body map[string]interface{}
+	json.NewDecoder(res.Body).Decode(&body)
+	c.JSON(res.StatusCode, body)
+
 }
 
 func test(c *gin.Context) {

--- a/main.go
+++ b/main.go
@@ -70,6 +70,22 @@ func serveCSS(c *gin.Context) {
 	serveFiles(c, "text/css", "./UI/styles/")
 }
 
+func status(c *gin.Context) {
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost:8080/status", nil)
+	res, _ := http.DefaultClient.Do(req)
+	c.JSON(res.StatusCode, gin.H{
+		"message": "check",
+	})
+}
+
+func test(c *gin.Context) {
+
+	fmt.Println(res)
+	c.JSON(200, gin.H{
+		"message": "pong",
+	})
+}
+
 func readIPCFG() {
 	f, err := os.Open("ip.cfg")
 	if err != nil {
@@ -93,5 +109,8 @@ func main() {
 	server.GET("/styles/:name", serveCSS)
 	server.PUT("/telemetry/", putTelemetry)
 	server.GET("/telemetry/", getTelemetry)
+	server.GET("/status", status)
+	server.GET("/test", test)
 	server.Run() // By default, it will start the server on http://localhost:8080
+
 }

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func readIPCFG() {
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		inData := strings.SplitAfter(scanner.Text(), ",")
+		inData := strings.Split(scanner.Text(), ",")
 		id, _ := strconv.Atoi(inData[1])
 		listIPs[id] = inData[0]
 	}


### PR DESCRIPTION
Task 795: Found out that the function that reads in the `ip.cfg` file also includes the seperator. I fixed that.

Task 724:
- Implemented GET /uplink
- It makes a call to Module 4 (GS-Uplink) and uses that to send the response.
- Note: In the documentation, "An error is returned if there were too many redirects or if there was an HTTP protocol error.". We can implement error handling for that, but I have left it without it for now as by design, such an event should not occur.