### PR TITLE
Task 826: UplinkDownlink /status/ call does not work

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,8 +124,7 @@ func serveCSS(c *gin.Context) {
 }
 
 func status(c *gin.Context) {
-	uri := fmt.Sprintf("http://%s:8080/status", listIPs[4])
-
+	uri := fmt.Sprintf("http://%s:8080/status/", listIPs[4])
 	//Error handling not implemented on purpose because
 	// "An error is returned if there were too many redirects or if there was an HTTP protocol error.
 	// A non-2xx response doesn't cause an error."


### PR DESCRIPTION
**main.go:**
- corrected the module 4 route
- Tested the route, and it works!

![image](https://github.com/Inventhrice/GroundStation_CNDH/assets/45127310/5192b6df-e251-44dd-a41b-2e4751a35b00)
