### PR TITLE
Task 819: Improving readIPCFG code

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,7 +125,6 @@ func serveCSS(c *gin.Context) {
 
 func status(c *gin.Context) {
 	uri := fmt.Sprintf("http://%s:8080/status/", listIPs[4])
-	fmt.Println(uri)
 	//Error handling not implemented on purpose because
 	// "An error is returned if there were too many redirects or if there was an HTTP protocol error.
 	// A non-2xx response doesn't cause an error."

--- a/main_test.go
+++ b/main_test.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-    "bytes"
+	"bytes"
 	"encoding/json"
-    "io"
-    "os"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -25,12 +25,12 @@ func Test01_PutTelemetry_ValidInput(t *testing.T) {
 	rot := Rotations{P: "1", Y: "1", R: "1"}
 	stat := Status{}
 	data := TelemetryData{Coordinates: coords, Rotations: rot, Status: stat}
-    // Convert data into JSON encoded byte array
-    jsonData, err := json.Marshal(data)
-    if err != nil {
-        t.Fatal(err)
-    }
-    body := bytes.NewReader(jsonData)
+	// Convert data into JSON encoded byte array
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := bytes.NewReader(jsonData)
 
 	server := SetupTestServer()
 
@@ -38,59 +38,59 @@ func Test01_PutTelemetry_ValidInput(t *testing.T) {
 	w := httptest.NewRecorder()
 	server.ServeHTTP(w, req)
 	actual, _ := io.ReadAll(w.Body)
-    expectedBody := "{\"message\":\"Data saved successfully!\"}" 
+	expectedBody := "{\"message\":\"Data saved successfully!\"}"
 	expectedCode := http.StatusOK
 
-    actualFilename := "telemetry.json"
-    actualJson, err := os.ReadFile(actualFilename)
-    if err != nil {
-        t.Fatal(err)
-    }
+	actualFilename := "telemetry.json"
+	actualJson, err := os.ReadFile(actualFilename)
+	if err != nil {
+		t.Fatal(err)
+	}
 	expectedFilename := "test/test1.json"
 	expectedJson, err := os.ReadFile(expectedFilename)
 	if err != nil {
-        t.Fatal(err)
+		t.Fatal(err)
 	}
 
 	assert.Equal(t, string(expectedBody), string(actual))
 	assert.Equal(t, expectedCode, w.Code)
-    assert.Equal(t, expectedJson, actualJson)
+	assert.Equal(t, expectedJson, actualJson)
 }
 
 func Test02_PutTelemetry_InvalidInput(t *testing.T) {
-    server := SetupTestServer()
+	server := SetupTestServer()
 
-    req, _ := http.NewRequest("PUT", "/telemetry/", nil)
-    w := httptest.NewRecorder()
-    server.ServeHTTP(w, req)
-    actual, _ := io.ReadAll(w.Body)
+	req, _ := http.NewRequest("PUT", "/telemetry/", nil)
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+	actual, _ := io.ReadAll(w.Body)
 
-    expectedCode := http.StatusBadRequest
-    expectedBody := "{\"error\":\"invalid request\"}"
+	expectedCode := http.StatusBadRequest
+	expectedBody := "{\"error\":\"invalid request\"}"
 
-    assert.Equal(t, expectedBody, string(actual))
-    assert.Equal(t, expectedCode, w.Code)
+	assert.Equal(t, expectedBody, string(actual))
+	assert.Equal(t, expectedCode, w.Code)
 }
 
 func Test03_GetTelemetry_Valid(t *testing.T) {
-    server := SetupTestServer()
+	server := SetupTestServer()
 
-    req, _ := http.NewRequest("GET", "/telemetry/", nil)
-    w := httptest.NewRecorder()
-    server.ServeHTTP(w, req)
-    actual, _ := io.ReadAll(w.Body)
+	req, _ := http.NewRequest("GET", "/telemetry/", nil)
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+	actual, _ := io.ReadAll(w.Body)
 
-    filename := "test/test3.tmpl"
-    //if err := os.WriteFile(filename, []byte(string(actual)), 0666); err != nil {
-    //    t.Fatal(err)
-    //}
-    expectedBody, err := os.ReadFile(filename)
-    if err != nil {
-        t.Fatal(err)
-    }
-    expectedCode := http.StatusOK
-    assert.Equal(t, string(expectedBody), string(actual))
-    assert.Equal(t, expectedCode, w.Code)
+	filename := "test/test3.tmpl"
+	//if err := os.WriteFile(filename, []byte(string(actual)), 0666); err != nil {
+	//    t.Fatal(err)
+	//}
+	expectedBody, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedCode := http.StatusOK
+	assert.Equal(t, string(expectedBody), string(actual))
+	assert.Equal(t, expectedCode, w.Code)
 }
 
 func Test04_Scripts_Valid(t *testing.T) {
@@ -106,9 +106,9 @@ func Test04_Scripts_Valid(t *testing.T) {
 	assert.Equal(t, expected, w.Body.String())
 }
 
-func Test04_Scripts_Invalid(t *testing.T) {
+func Test05_Scripts_Invalid(t *testing.T) {
 	expected := "{\"error\":\"open ./UI/scripts/NOTFOUND.js: no such file or directory\"}"
-    expectedCode := http.StatusNotFound
+	expectedCode := http.StatusNotFound
 	server := SetupTestServer()
 
 	req, _ := http.NewRequest("GET", "/scripts/NOTFOUND.js", nil)
@@ -117,10 +117,10 @@ func Test04_Scripts_Invalid(t *testing.T) {
 	server.ServeHTTP(w, req)
 
 	assert.Equal(t, expected, w.Body.String())
-    assert.Equal(t, expectedCode, w.Code)
+	assert.Equal(t, expectedCode, w.Code)
 }
 
-func Test05_Styles_Valid(t *testing.T) {
+func Test06_Styles_Valid(t *testing.T) {
 	expected := "testTextfor css file"
 
 	server := SetupTestServer()
@@ -133,25 +133,21 @@ func Test05_Styles_Valid(t *testing.T) {
 	assert.Equal(t, expected, w.Body.String())
 }
 
-func Test05_Styles_Invalid(t *testing.T) {
+func Test07_Styles_Invalid(t *testing.T) {
 	expected := "{\"error\":\"open ./UI/styles/NOTFOUND.css: no such file or directory\"}"
-    expectedCode := http.StatusNotFound
+	expectedCode := http.StatusNotFound
 	server := SetupTestServer()
 
 	req, _ := http.NewRequest("GET", "/styles/NOTFOUND.css", nil)
 	w := httptest.NewRecorder()
 
 	server.ServeHTTP(w, req)
-    
+
 	assert.Equal(t, expected, w.Body.String())
-    assert.Equal(t, expectedCode, w.Code)
+	assert.Equal(t, expectedCode, w.Code)
 }
 
-// func Test06_HTML(t *testing.T){
-
-// }
-
-func Test07_Root(t *testing.T) {
+func Test08_Root(t *testing.T) {
 	expected := http.StatusOK
 	expectedMsg := "{\"message\":\"Server is running\"}"
 
@@ -166,6 +162,10 @@ func Test07_Root(t *testing.T) {
 	assert.Equal(t, expectedMsg, w.Body.String())
 }
 
-// func test08_readIPCFG(t *testing.T){
+func test09_readIPCFG_Valid(t *testing.T) {
 
-// }
+}
+
+func test10_readIPCFG_Invalid(t *testing.T) {
+
+}

--- a/main_test.go
+++ b/main_test.go
@@ -163,9 +163,11 @@ func Test08_Root(t *testing.T) {
 }
 
 func test09_readIPCFG_Valid(t *testing.T) {
-
+	_, err := readIPCFG("ip.cfg")
+	assert.Nil(t, err)
 }
 
 func test10_readIPCFG_Invalid(t *testing.T) {
-
+	_, err := readIPCFG("nilpath.cfg")
+	assert.NotNil(t, err)
 }


### PR DESCRIPTION
Changes made:
main.go:
- Changed the readIPCFG functions mainly. It now returns the lsit of ips along with any errors if they occur. The list of ips will be blank if err != nil.
- Moved the print statement to the main function

This change was made to conform to the standard Go function, along with making it easier to test the function. Now, if the program can't read the ip.cfg file, it gracefully exits.

main_test.go:
- Wrote two tests for the readIFCFG() function to test if it returns the correct errors.
- Rewrote the function names for the other tests to have unique test numbers.