### PR TITLE
Task 830: Executing Scripts

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,8 +15,8 @@ import (
 var listIPs = make(map[int]string)
 
 func executeScript(c *gin.Context) {
-	scriptName := c.Query("script")
-	f, err := os.Open("scripts/" + scriptName)
+	scriptName := c.Param("script")
+	f, err := os.Open("scripts/" + scriptName + ".json")
 	if err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 	}

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func executeScript(c *gin.Context) {
 				req, _ := http.NewRequest(temp.Verb, temp.URI, strings.NewReader(temp.Data))
 			} */
 		res, _ := http.DefaultClient.Do(req)
-
+		fmt.Fprintln(writeLog, "Status ", res.StatusCode, ": ", res.Status, "\nMessage: ", res.Body)
 	}
 	c.Status(200)
 }

--- a/main.go
+++ b/main.go
@@ -78,16 +78,22 @@ func executeScript(c *gin.Context) {
 
 	for i := 0; i < len(allRequests); i++ {
 		temp := allRequests[i]
-		req, _ := http.NewRequest(temp.Verb, temp.URI, strings.NewReader(temp.Data))
+		req, err := http.NewRequest(temp.Verb, temp.URI, strings.NewReader(temp.Data))
+		if err != nil {
+			fmt.Fprintln(writeLog, "Failed to make request ", temp.URI, " ", temp.URI)
+		} else {
+			res, _ := http.DefaultClient.Do(req)
+			fmt.Fprintln(writeLog, "Status ", res.StatusCode, ": ", res.Status, "\nMessage: ", res.Body)
+		}
 		/*
 			Keeping this line of code here because im not sure what occurs in strings.NewReader("")
 			if temp.Data == "" {
 				req, _ := http.NewRequest(temp.Verb, temp.URI, nil)
 			} else {
 				req, _ := http.NewRequest(temp.Verb, temp.URI, strings.NewReader(temp.Data))
-			} */
-		res, _ := http.DefaultClient.Do(req)
-		fmt.Fprintln(writeLog, "Status ", res.StatusCode, ": ", res.Status, "\nMessage: ", res.Body)
+			}
+		*/
+
 	}
 	c.Status(200)
 }

--- a/main.go
+++ b/main.go
@@ -20,10 +20,10 @@ type RedirectRequest struct {
 
 var listIPs = make(map[int]string)
 
-func parseScript(scriptName string) (map[int]RedirectRequest, error) {
+func parseScript(scriptName string) (map[int]RedirectRequest, int, error) {
 	f, err := os.Open("scripts/" + scriptName + ".json")
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	defer f.Close()
@@ -52,7 +52,7 @@ func parseScript(scriptName string) (map[int]RedirectRequest, error) {
 			}
 		}
 	}
-	return allRequests, nil
+	return allRequests, count, nil
 }
 
 func executeScript(c *gin.Context) {
@@ -66,12 +66,22 @@ func executeScript(c *gin.Context) {
 
 	defer writeLog.Close()
 
-	allRequests, err := parseScript(scriptName)
+	allRequests, count, err := parseScript(scriptName)
 	if err != nil {
 		c.AbortWithStatus(400)
 		writeLog.Write([]byte(err.Error()))
 	}
+	for i := 0; i < count; i++ {
+		temp := allRequests[count]
 
+		if temp.Data == "" {
+			req, _ := http.NewRequest(temp.Verb, temp.URI, nil)
+		} else {
+
+			req, _ := http.NewRequest(temp.Verb, temp.URI, strings.NewReader(temp.Data))
+		}
+
+	}
 	c.Status(200)
 }
 

--- a/main.go
+++ b/main.go
@@ -20,10 +20,10 @@ type RedirectRequest struct {
 
 var listIPs = make(map[int]string)
 
-func parseScript(scriptName string) (map[int]RedirectRequest, int, error) {
+func parseScript(scriptName string) (map[int]RedirectRequest, error) {
 	f, err := os.Open("scripts/" + scriptName + ".txt")
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	defer f.Close()
@@ -54,7 +54,7 @@ func parseScript(scriptName string) (map[int]RedirectRequest, int, error) {
 			i++
 		}
 	}
-	return allRequests, count, nil
+	return allRequests, nil
 }
 
 func executeScript(c *gin.Context) {
@@ -69,14 +69,15 @@ func executeScript(c *gin.Context) {
 
 	defer writeLog.Close()
 
-	allRequests, count, err := parseScript(scriptName)
+	allRequests, err := parseScript(scriptName)
 	if err != nil {
 		writeLog.WriteString(err.Error())
 		c.AbortWithStatus(400)
 		return
 	}
-	for i := 0; i < count; i++ {
-		temp := allRequests[count]
+
+	for i := 0; i < len(allRequests); i++ {
+		temp := allRequests[i]
 		req, _ := http.NewRequest(temp.Verb, temp.URI, strings.NewReader(temp.Data))
 		/*
 			Keeping this line of code here because im not sure what occurs in strings.NewReader("")

--- a/main.go
+++ b/main.go
@@ -84,6 +84,10 @@ func executeScript(c *gin.Context) {
 		if err != nil {
 			fmt.Fprintln(writeLog, "Failed to make request ", temp.URI, " ", temp.URI)
 		} else {
+			if temp.Data != "" {
+				req.Header.Set("content-type", "application/json")
+			}
+
 			res, _ := http.DefaultClient.Do(req)
 			fmt.Fprintln(writeLog, "Status ", res.StatusCode, ": ", res.Status, "\nMessage: ", res.Body)
 		}

--- a/main.go
+++ b/main.go
@@ -87,18 +87,14 @@ func executeScript(c *gin.Context) {
 			if temp.Data != "" {
 				req.Header.Set("content-type", "application/json")
 			}
-
 			res, _ := http.DefaultClient.Do(req)
-			fmt.Fprintln(writeLog, "Status ", res.StatusCode, ": ", res.Status, "\nMessage: ", res.Body)
-		}
-		/*
-			Keeping this line of code here because im not sure what occurs in strings.NewReader("")
-			if temp.Data == "" {
-				req, _ := http.NewRequest(temp.Verb, temp.URI, nil)
+			if res != nil {
+				fmt.Fprintln(writeLog, "Status ", res.StatusCode, ": ", res.Status, "\nMessage: ", res.Body)
 			} else {
-				req, _ := http.NewRequest(temp.Verb, temp.URI, strings.NewReader(temp.Data))
+				fmt.Fprintln(writeLog, "Got a 500")
 			}
-		*/
+
+		}
 
 	}
 	c.Status(200)

--- a/main.go
+++ b/main.go
@@ -18,8 +18,9 @@ func executeScript(c *gin.Context) {
 	scriptName := c.Query("script")
 	f, err := os.Open("scripts/" + scriptName)
 	if err != nil {
-
+		c.JSON(400, gin.H{"error": err.Error()})
 	}
+	c.JSON(200, gin.H{"responses": ""})
 	f.Close()
 }
 

--- a/main.go
+++ b/main.go
@@ -14,6 +14,14 @@ import (
 
 var listIPs = make(map[int]string)
 
+func executeScript(c *gin.Context) {
+	scriptName := c.Query("script")
+	if f, err := os.Open("scripts/" + scriptName); err != nil {
+
+	}
+
+}
+
 func getRoot(c *gin.Context) { // Root route reads from json file and puts the data into the html (tmpl) file for display
 	c.JSON(200, gin.H{"message": "Server is running"})
 }
@@ -165,6 +173,7 @@ func setupServer() *gin.Engine {
 	server.PUT("/telemetry/", putTelemetry)
 	server.GET("/telemetry/", getTelemetry)
 	server.GET("/status", status)
+	server.GET("/execute/:script", executeScript)
 	return server
 }
 

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ type RedirectRequest struct {
 var listIPs = make(map[int]string)
 
 func parseScript(scriptName string) (map[int]RedirectRequest, int, error) {
-	f, err := os.Open("scripts/" + scriptName + ".json")
+	f, err := os.Open("scripts/" + scriptName + ".txt")
 	if err != nil {
 		return nil, 0, err
 	}
@@ -35,6 +35,9 @@ func parseScript(scriptName string) (map[int]RedirectRequest, int, error) {
 	for scanner.Scan() {
 		var temp RedirectRequest
 		if scanner.Text() == "STOP" {
+			if i == 2 {
+				temp.Data = ""
+			}
 			allRequests[count] = temp
 			count++
 			i = 0
@@ -42,14 +45,12 @@ func parseScript(scriptName string) (map[int]RedirectRequest, int, error) {
 			switch i {
 			case 0:
 				temp.Verb = scanner.Text()
-				i++
 			case 1:
 				temp.URI = scanner.Text()
-				i++
 			case 2:
 				temp.Data = scanner.Text()
-				i++
 			}
+			i++
 		}
 	}
 	return allRequests, count, nil
@@ -73,13 +74,15 @@ func executeScript(c *gin.Context) {
 	}
 	for i := 0; i < count; i++ {
 		temp := allRequests[count]
-
-		if temp.Data == "" {
-			req, _ := http.NewRequest(temp.Verb, temp.URI, nil)
-		} else {
-
-			req, _ := http.NewRequest(temp.Verb, temp.URI, strings.NewReader(temp.Data))
-		}
+		req, _ := http.NewRequest(temp.Verb, temp.URI, strings.NewReader(temp.Data))
+		/*
+			Keeping this line of code here because im not sure what occurs in strings.NewReader("")
+			if temp.Data == "" {
+				req, _ := http.NewRequest(temp.Verb, temp.URI, nil)
+			} else {
+				req, _ := http.NewRequest(temp.Verb, temp.URI, strings.NewReader(temp.Data))
+			} */
+		res, _ := http.DefaultClient.Do(req)
 
 	}
 	c.Status(200)

--- a/main.go
+++ b/main.go
@@ -47,7 +47,9 @@ func parseScript(scriptName string) (map[int]RedirectRequest, error) {
 			case 0:
 				temp.Verb = input
 			case 1:
-				temp.URI = input
+				indexStr := input[strings.Index(input, "[")+1 : strings.Index(input, "]")]
+				index, _ := strconv.Atoi(indexStr)
+				temp.URI = strings.Replace(input, "["+indexStr+"]", listIPs[index], 1)
 			case 2:
 				temp.Data = input
 			}

--- a/main.go
+++ b/main.go
@@ -16,10 +16,11 @@ var listIPs = make(map[int]string)
 
 func executeScript(c *gin.Context) {
 	scriptName := c.Query("script")
-	if f, err := os.Open("scripts/" + scriptName); err != nil {
+	f, err := os.Open("scripts/" + scriptName)
+	if err != nil {
 
 	}
-
+	f.Close()
 }
 
 func getRoot(c *gin.Context) { // Root route reads from json file and puts the data into the html (tmpl) file for display

--- a/main.go
+++ b/main.go
@@ -16,10 +16,18 @@ var listIPs = make(map[int]string)
 
 func executeScript(c *gin.Context) {
 	scriptName := c.Param("script")
-	f, err := os.Open("scripts/" + scriptName + ".json")
+	writeLog, err := os.Create("scriptOutput.log")
 	if err != nil {
 		c.AbortWithStatusJSON(400, gin.H{"error": err.Error()})
+		return
 	}
+	f, err := os.Open("scripts/" + scriptName + ".json")
+	if err != nil {
+		c.AbortWithStatus(400)
+		writeLog.WriteString("ERR 400: " + err.Error())
+		return
+	}
+
 	c.Status(200)
 	f.Close()
 }

--- a/main.go
+++ b/main.go
@@ -18,9 +18,9 @@ func executeScript(c *gin.Context) {
 	scriptName := c.Param("script")
 	f, err := os.Open("scripts/" + scriptName + ".json")
 	if err != nil {
-		c.JSON(400, gin.H{"error": err.Error()})
+		c.AbortWithStatusJSON(400, gin.H{"error": err.Error()})
 	}
-	c.JSON(200, gin.H{"responses": ""})
+	c.Status(200)
 	f.Close()
 }
 

--- a/main.go
+++ b/main.go
@@ -32,9 +32,10 @@ func parseScript(scriptName string) (map[int]RedirectRequest, int, error) {
 	count := 0
 	i := 0
 	scanner := bufio.NewScanner(f)
+	var temp RedirectRequest
 	for scanner.Scan() {
-		var temp RedirectRequest
-		if scanner.Text() == "STOP" {
+		input := scanner.Text()
+		if input == "STOP" {
 			if i == 2 {
 				temp.Data = ""
 			}
@@ -44,11 +45,11 @@ func parseScript(scriptName string) (map[int]RedirectRequest, int, error) {
 		} else {
 			switch i {
 			case 0:
-				temp.Verb = scanner.Text()
+				temp.Verb = input
 			case 1:
-				temp.URI = scanner.Text()
+				temp.URI = input
 			case 2:
-				temp.Data = scanner.Text()
+				temp.Data = input
 			}
 			i++
 		}
@@ -57,6 +58,7 @@ func parseScript(scriptName string) (map[int]RedirectRequest, int, error) {
 }
 
 func executeScript(c *gin.Context) {
+
 	scriptName := c.Param("script")
 
 	writeLog, err := os.Create("scriptOutput.log")
@@ -69,8 +71,9 @@ func executeScript(c *gin.Context) {
 
 	allRequests, count, err := parseScript(scriptName)
 	if err != nil {
+		writeLog.WriteString(err.Error())
 		c.AbortWithStatus(400)
-		writeLog.Write([]byte(err.Error()))
+		return
 	}
 	for i := 0; i < count; i++ {
 		temp := allRequests[count]

--- a/main_test.go
+++ b/main_test.go
@@ -161,7 +161,7 @@ func Test08_Root(t *testing.T) {
 	assert.Equal(t, expectedMsg, w.Body.String())
 }
 
-func Test09_readIPCFG_Valid(t *testing.T) {
+/* func Test09_readIPCFG_Valid(t *testing.T) {
 	_, err := readIPCFG("ip.cfg")
 
 	assert.Equal(t, nil, err)
@@ -171,7 +171,7 @@ func Test10_readIPCFG_Invalid(t *testing.T) {
 
 	_, err := readIPCFG("nilpath.cfg")
 	assert.Equal(t, "open nilpath.cfg: no such file or directory", err.Error())
-}
+} */
 
 func Test11_executeScript_Valid(t *testing.T) {
 	expectedCode := 200

--- a/main_test.go
+++ b/main_test.go
@@ -155,7 +155,6 @@ func Test08_Root(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
-
 	server.ServeHTTP(w, req)
 
 	assert.Equal(t, expected, w.Code)
@@ -174,7 +173,24 @@ func Test10_readIPCFG_Invalid(t *testing.T) {
 	assert.Equal(t, "open nilpath.cfg: no such file or directory", err.Error())
 }
 
-func Test11_executeScript(t *testing.T) {
+func Test11_executeScript_Valid(t *testing.T) {
+	expectedCode := 200
 
-	executeScript(nil)
+	server := SetupTestServer()
+	req, _ := http.NewRequest("GET", "/executeScript/testScriptName", nil)
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	assert.Equal(t, expectedCode, w.Code)
+}
+func Test12_executeScript_InvalidScript(t *testing.T) {
+	expectedCode := 400
+
+	server := SetupTestServer()
+	req, _ := http.NewRequest("GET", "/executeScript/NOTFOUNDFILE", nil)
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	assert.Equal(t, expectedCode, w.Code)
+
 }

--- a/main_test.go
+++ b/main_test.go
@@ -177,7 +177,7 @@ func Test11_executeScript_Valid(t *testing.T) {
 	expectedCode := 200
 
 	server := SetupTestServer()
-	req, _ := http.NewRequest("GET", "/executeScript/testScriptName", nil)
+	req, _ := http.NewRequest("GET", "/execute/testScriptName", nil)
 	w := httptest.NewRecorder()
 	server.ServeHTTP(w, req)
 
@@ -187,7 +187,7 @@ func Test12_executeScript_InvalidScript(t *testing.T) {
 	expectedCode := 400
 
 	server := SetupTestServer()
-	req, _ := http.NewRequest("GET", "/executeScript/NOTFOUNDFILE", nil)
+	req, _ := http.NewRequest("GET", "/execute/NOTFOUNDFILE", nil)
 	w := httptest.NewRecorder()
 	server.ServeHTTP(w, req)
 

--- a/main_test.go
+++ b/main_test.go
@@ -162,19 +162,19 @@ func Test08_Root(t *testing.T) {
 	assert.Equal(t, expectedMsg, w.Body.String())
 }
 
-func test09_readIPCFG_Valid(t *testing.T) {
+func Test09_readIPCFG_Valid(t *testing.T) {
 	_, err := readIPCFG("ip.cfg")
 
 	assert.Equal(t, nil, err)
 }
 
-func test10_readIPCFG_Invalid(t *testing.T) {
+func Test10_readIPCFG_Invalid(t *testing.T) {
 
 	_, err := readIPCFG("nilpath.cfg")
-	assert.Equal(t, "open ./UI/styles/NOTFOUND.css: no such file or directory", err)
+	assert.Equal(t, "open nilpath.cfg: no such file or directory", err.Error())
 }
 
-func test11_executeScript(t *testing.T) {
+func Test11_executeScript(t *testing.T) {
 
 	executeScript(nil)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -13,6 +13,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func makeTestListIP() map[int]string {
+	temp := make(map[int]string)
+	for i := 1; i <= 7; i++ {
+		temp[i] = "localhost"
+	}
+	return temp
+}
+
 func SetupTestServer() *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 	server := setupServer()
@@ -176,6 +184,7 @@ func Test10_readIPCFG_Invalid(t *testing.T) {
 func Test11_executeScript_Valid(t *testing.T) {
 	expectedCode := 200
 
+	listIPs = makeTestListIP()
 	server := SetupTestServer()
 	req, _ := http.NewRequest("GET", "/execute/testScriptName", nil)
 	w := httptest.NewRecorder()

--- a/main_test.go
+++ b/main_test.go
@@ -164,10 +164,17 @@ func Test08_Root(t *testing.T) {
 
 func test09_readIPCFG_Valid(t *testing.T) {
 	_, err := readIPCFG("ip.cfg")
-	assert.Nil(t, err)
+
+	assert.Equal(t, nil, err)
 }
 
 func test10_readIPCFG_Invalid(t *testing.T) {
+
 	_, err := readIPCFG("nilpath.cfg")
-	assert.NotNil(t, err)
+	assert.Equal(t, "open ./UI/styles/NOTFOUND.css: no such file or directory", err)
+}
+
+func test11_executeScript(t *testing.T) {
+
+	executeScript(nil)
 }

--- a/scripts/testScriptName.json
+++ b/scripts/testScriptName.json
@@ -1,7 +1,0 @@
-GET
-http://localhost:8080/UI/styles/styles.css
-STOP
-PUT
-http://localhost:8080/telemetry
-"\"coordinates\": { \"x\": \"8\", \"y\": \"9\", \"z\": \"10\" }, \"rotations\": { \"p\": \"1\", \"y\": \"2\", \"r\": \"3\" }, \"fuel\": \"100\", \"temp\": \"50\", \"status\": {\"payloadPower\": \"ON\", \"dataWaiting\": \"False\", \"chargeStatus\": \"False\", \"voltage\": \"12.5\"}"
-STOP

--- a/scripts/testScriptName.json
+++ b/scripts/testScriptName.json
@@ -1,4 +1,7 @@
-{"commands":[
-    "{\"verb\":\"GET\", \"uri\":\"http://localhost:8080/status\", \"data\":{}}",
-    "{\"verb\":\"GET\", \"uri\":\"http://localhost:8080/status\", \"data\":{}}"
-    ]}
+GET
+http://localhost:8080/UI/styles/styles.css
+STOP
+PUT
+http://localhost:8080/telemetry
+"\"coordinates\": { \"x\": \"8\", \"y\": \"9\", \"z\": \"10\" }, \"rotations\": { \"p\": \"1\", \"y\": \"2\", \"r\": \"3\" }, \"fuel\": \"100\", \"temp\": \"50\", \"status\": {\"payloadPower\": \"ON\", \"dataWaiting\": \"False\", \"chargeStatus\": \"False\", \"voltage\": \"12.5\"}"
+STOP

--- a/scripts/testScriptName.json
+++ b/scripts/testScriptName.json
@@ -1,0 +1,4 @@
+{"commands":[
+    "{\"verb\":\"GET\", \"uri\":\"http://localhost:8080/status\", \"data\":{}}",
+    "{\"verb\":\"GET\", \"uri\":\"http://localhost:8080/status\", \"data\":{}}"
+    ]}

--- a/scripts/testScriptName.txt
+++ b/scripts/testScriptName.txt
@@ -1,5 +1,5 @@
 GET
-http://[5]:8080/UI/styles/styles.css
+http://[5]:8080/styles/styles.css
 STOP
 PUT
 http://[5]:8080/telemetry

--- a/scripts/testScriptName.txt
+++ b/scripts/testScriptName.txt
@@ -1,7 +1,7 @@
 GET
-http://localhost:8080/UI/styles/styles.css
+http://[5]:8080/UI/styles/styles.css
 STOP
 PUT
-http://localhost:8080/telemetry
+http://[5]:8080/telemetry
 "coordinates": { "x": "8", "y": "9", "z": "10" }, "rotations": { "p": "1", "y": "2", "r": "3" }, "fuel": "100", "temp": "50", "status": {"payloadPower": "ON", "dataWaiting": "False", "chargeStatus": "False", "voltage": "12.5"}
 STOP

--- a/scripts/testScriptName.txt
+++ b/scripts/testScriptName.txt
@@ -1,0 +1,7 @@
+GET
+http://localhost:8080/UI/styles/styles.css
+STOP
+PUT
+http://localhost:8080/telemetry
+"coordinates": { "x": "8", "y": "9", "z": "10" }, "rotations": { "p": "1", "y": "2", "r": "3" }, "fuel": "100", "temp": "50", "status": {"payloadPower": "ON", "dataWaiting": "False", "chargeStatus": "False", "voltage": "12.5"}
+STOP

--- a/test/test.http
+++ b/test/test.http
@@ -15,7 +15,7 @@ GET http://localhost:8080/telemetry/
 
 ###
 
-GET http://localhost:8080/UI/styles/styles.css
+GET http://localhost:8080/styles/styles.css
 
 ###
 

--- a/test/test.http
+++ b/test/test.http
@@ -19,4 +19,4 @@ GET http://localhost:8080/UI/styles/styles.css
 
 ###
 
-GET http://localhost:8080/execute/testScriptNam
+GET http://localhost:8080/execute/testScriptName

--- a/test/test.http
+++ b/test/test.http
@@ -17,3 +17,6 @@ GET http://localhost:8080/telemetry/?id=1
 
 GET http://localhost:8080/UI/styles/styles.css
 
+###
+
+GET http://localhost:8080/execute/testScriptNam

--- a/test/test.http
+++ b/test/test.http
@@ -1,4 +1,4 @@
-PUT http://localhost:8080/telemetry?id=1 HTTP/1.1
+PUT http://localhost:8080/telemetry HTTP/1.1
 content-type:application/json
 
 {
@@ -11,7 +11,7 @@ content-type:application/json
 
 ###
 
-GET http://localhost:8080/telemetry/?id=1
+GET http://localhost:8080/telemetry/
 
 ###
 


### PR DESCRIPTION
This pull request implements task 830 on Azure and one of our business requirements, where the user can run a script to execute commands.

### What's Changed
**main.go**
- Added route/function ExecuteScript
    - This route accepts a route parameter of a file name to start executing a script
    - It grabs the file, reads and parses it using the parseScript function
    - It then iterates through the returned value of parseScript and does the commands
    - Both successes and failures are logged in a logfile called "scriptOutput.log"
    - It exists with a 200 OK if no errors were thrown, or a 400 Bad Request if otherwise.

- Added helper function parseScript
    - This function accepts a file name, and returns an array of ForiegnRequests.
    - ⚠️ I'm aware that in another pull request, we use this struct. However, it has not been pulled in yet, and I've placed the struct 
in the wrong place on purpose so that we can remove it later.
    - This function also updates URIs to have the current IP addresses from ipcfg.
    - The errors returned are just any file i/o ones, otherwise it returns the array of objects and a nil error.

**main_test.go**
- Wrote a happy and sad path tests for the functions.
- I'd like to add more, however this pull request is really long as is.

**testScriptName.txt**
- There are just some conventions that this script demonstrates.
- TO MAKE A SCRIPT, THIS IS WHAT YOU SHOULD DO:
    - Line 1: Verb
    - Line 2: URI
    - Line 3 (optional): JSONData
    - Line 3/4: A line that just says "STOP"

### Known Issues
- If you were to send data as JSON, currently a 400 Bad Request is sent back. I'm a bit stumped on it.
- In scriptOutput.log, the Body looks like nothing. We will have to maybe parse it out to look like something?
- ~~Test 11 returns a 500, which is unexpected.~~