### PR TITLE
ID925 - Fixed IP used in requestTelemetry.

### DIFF
--- a/main.go
+++ b/main.go
@@ -250,7 +250,7 @@ func requestTelemetry(c *gin.Context) {
 	uri := fmt.Sprintf("http://%s:8080/send/", listIPs[4])
 
 	// Create JSON
-	json := "{\"verb\":\"GET\",\"uri\":\"http://" + listIPs[2] + ":8080/send/\"}"
+	json := "{\"verb\":\"GET\",\"uri\":\"http://" + listIPs[1] + ":8080/send/\"}"
 	body := strings.NewReader(json)
 
 	res, err := http.NewRequest("POST", uri, body)


### PR DESCRIPTION
### Changes made
#### main.go
:green_circle: Fixed destination IP used in requestTelemetry. I now uses module 1's address. 